### PR TITLE
Tiny path fix & Deployment Files for CPU only deployment

### DIFF
--- a/Dockerfile_CPU.api
+++ b/Dockerfile_CPU.api
@@ -1,0 +1,12 @@
+# This Dockerfile builds the API only.
+
+FROM python:slim
+WORKDIR /app
+
+COPY api/requirements_cpu.txt api/api.py api/.flaskenv ./
+RUN mkdir -p ./static/files
+RUN pip install -r ./requirements_cpu.txt
+ENV FLASK_ENV production
+
+EXPOSE 5000
+CMD ["gunicorn", "-b", ":5000", "api:app"]

--- a/api/requirements_cpu.txt
+++ b/api/requirements_cpu.txt
@@ -6,6 +6,8 @@ gunicorn==20.1.0
 itsdangerous==2.1.2
 Jinja2==3.1.2
 MarkupSafe==2.1.2
+--extra-index-url https://download.pytorch.org/whl/cpu
+torch==1.13.1
 Pillow==9.5.0
 python-dotenv==1.0.0
 python-magic==0.4.27

--- a/api/service.py
+++ b/api/service.py
@@ -43,7 +43,7 @@ class Service:
         ]
 
         self.path_input_file = os.path.join(
-            self.upload_folder, self.token + "." + self.output_extension
+            self.upload_folder, self.token + "." + self.input_extension
         )
         self.path_processed_file = os.path.join(
             self.upload_folder, self.token + self.suffix + "." + self.output_extension


### PR DESCRIPTION
Often `service.py` might utilize pyTorch. By default, it downloads a version that supports GPU. This makes the resulting docker container/deployment size huge (several GB). Now there's a `requirements_cpu.txt` and a dockerfile that utilizes it, which uses not only a small python image but also downloads an pyTorch version that's CPU only. The resulting docker image is now several hundred MB, much smaller.